### PR TITLE
Merge unit tests fixes from dev

### DIFF
--- a/exams/tests.py
+++ b/exams/tests.py
@@ -35,16 +35,16 @@ class ExamsViewSetTestCase(APITestCase):
             subject=self.subject1,
             date=self.date,
             clazz=self.clazz,
-            topic='Quadratic inequations',
-            details='This will be the hardest **** ever!!!',
+            topic='test topic 1',
+            details='detailed information',
             author=self.teacher
         )
         self.exam2 = Exam.objects.create(
             subject=self.subject2,
             date=self.date,
             clazz=self.clazz,
-            topic='Realism',
-            details='idk idk dik',
+            topic='test topic 2',
+            details='detailed information',
             author=self.teacher
         )
 
@@ -62,10 +62,7 @@ class ExamsViewSetTestCase(APITestCase):
             reverse(self.detail_view_name, kwargs={'pk': self.exam1.id})
         )
 
-        self.assertEqual(
-            response.data['detail'],
-            'Authentication credentials were not provided.'
-        )
+        self.assertEqual(response.data['detail'], 'Authentication credentials were not provided.')
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_exams_list_with_student_user(self):
@@ -73,9 +70,7 @@ class ExamsViewSetTestCase(APITestCase):
 
         response = self.client.get(reverse(self.list_view_name))
 
-        self.assertEqual(
-            self.subject1.title, response.data['results'][1]['subject']['title']
-        )
+        self.assertEqual(self.subject1.title, response.data['results'][1]['subject']['title'])
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_exams_list_with_teacher_user(self):
@@ -90,9 +85,7 @@ class ExamsViewSetTestCase(APITestCase):
     def test_exams_detail_with_authenticated_user(self):
         self.client.force_authenticate(user=self.student_user)
 
-        response = self.client.get(
-            reverse(self.detail_view_name, kwargs={'pk': self.exam1.id})
-        )
+        response = self.client.get(reverse(self.detail_view_name, kwargs={'pk': self.exam1.id}))
 
         self.assertIsNotNone(response.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -115,9 +108,7 @@ class ExamsViewSetTestCase(APITestCase):
     def test_exams_detail_with_invalid_id(self):
         self.client.force_authenticate(user=self.student_user)
 
-        response = self.client.get(
-            reverse(self.detail_view_name, kwargs={'pk': self.exam2.id + 1})
-        )
+        response = self.client.get(reverse(self.detail_view_name, kwargs={'pk': self.exam2.id + 1}))
 
         self.assertEqual(response.data['detail'], 'Not found.')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
@@ -125,9 +116,7 @@ class ExamsViewSetTestCase(APITestCase):
     def test_exams_detail_with_valid_id(self):
         self.client.force_authenticate(user=self.student_user)
 
-        response = self.client.get(
-            reverse(self.detail_view_name, kwargs={'pk': self.exam1.id})
-        )
+        response = self.client.get(reverse(self.detail_view_name, kwargs={'pk': self.exam1.id}))
 
         self.assertEqual(response.data['details'], self.exam1.details)
         self.assertEqual(response.data['topic'], self.exam1.topic)
@@ -136,12 +125,10 @@ class ExamsViewSetTestCase(APITestCase):
 
     def test_exams_creation_with_student_account(self):
         self.client.force_authenticate(user=self.student_user)
-        self.exam1.topic = 'glucimir'
+        self.exam1.topic = 'test topic'
         post_data = self.serializer_class(self.exam1).data
 
-        response = self.client.post(
-            reverse(self.list_view_name), post_data, format='json'
-        )
+        response = self.client.post(reverse(self.list_view_name), post_data, format='json')
 
         self.assertEqual(
             response.data['detail'],
@@ -154,21 +141,17 @@ class ExamsViewSetTestCase(APITestCase):
         self.exam1.topic = ''
         post_data = self.serializer_class(self.exam1).data
 
-        response = self.client.post(
-            reverse(self.list_view_name), post_data, format='json'
-        )
+        response = self.client.post(reverse(self.list_view_name), post_data, format='json')
 
         self.assertEqual(response.data['topic'], ['This field may not be blank.'])
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_exams_creation_with_too_long_topic(self):
         self.client.force_authenticate(user=self.teacher_user)
-        self.exam1.topic = 'glucimir' * 20
+        self.exam1.topic = 'test topic' * 20
         post_data = self.serializer_class(self.exam1).data
 
-        response = self.client.post(
-            reverse(self.list_view_name), post_data, format='json'
-        )
+        response = self.client.post(reverse(self.list_view_name), post_data, format='json')
 
         self.assertEqual(
             response.data['topic'],
@@ -178,24 +161,20 @@ class ExamsViewSetTestCase(APITestCase):
 
     def test_exams_creation_with_valid_topic(self):
         self.client.force_authenticate(user=self.teacher_user)
-        self.exam1.topic = 'glucimir'
+        self.exam1.topic = 'test topic'
         post_data = self.serializer_class(self.exam1).data
 
-        response = self.client.post(
-            reverse(self.list_view_name), post_data, format='json'
-        )
+        response = self.client.post(reverse(self.list_view_name), post_data, format='json')
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_exams_update_with_student_account(self):
         self.client.force_authenticate(user=self.student_user)
-        self.exam1.topic = 'glucimir'
+        self.exam1.topic = 'test topic'
         put_data = self.serializer_class(self.exam1).data
 
         response = self.client.put(
-            reverse(self.detail_view_name, kwargs={'pk': self.exam1.id}),
-            put_data,
-            format='json'
+            reverse(self.detail_view_name, kwargs={'pk': self.exam1.id}), put_data, format='json'
         )
 
         self.assertEqual(
@@ -210,9 +189,7 @@ class ExamsViewSetTestCase(APITestCase):
         put_data = self.serializer_class(self.exam1).data
 
         response = self.client.put(
-            reverse(self.detail_view_name, kwargs={'pk': self.exam1.id}),
-            put_data,
-            format='json'
+            reverse(self.detail_view_name, kwargs={'pk': self.exam1.id}), put_data, format='json'
         )
 
         self.assertEqual(response.data['topic'], ['This field may not be blank.'])
@@ -220,13 +197,11 @@ class ExamsViewSetTestCase(APITestCase):
 
     def test_exams_update_with_too_long_topic(self):
         self.client.force_authenticate(user=self.teacher_user)
-        self.exam1.topic = 'glucimir' * 20
+        self.exam1.topic = 'test topic' * 20
         put_data = self.serializer_class(self.exam1).data
 
         response = self.client.put(
-            reverse(self.detail_view_name, kwargs={'pk': self.exam1.id}),
-            put_data,
-            format='json'
+            reverse(self.detail_view_name, kwargs={'pk': self.exam1.id}), put_data, format='json'
         )
 
         self.assertEqual(
@@ -257,13 +232,11 @@ class ExamsViewSetTestCase(APITestCase):
 
     def test_exams_update_with_valid_topic(self):
         self.client.force_authenticate(user=self.teacher_user)
-        self.exam1.topic = 'glucimir'
+        self.exam1.topic = 'test topic'
         put_data = self.serializer_class(self.exam1).data
 
         response = self.client.put(
-            reverse(self.detail_view_name, kwargs={'pk': self.exam1.id}),
-            put_data,
-            format='json'
+            reverse(self.detail_view_name, kwargs={'pk': self.exam1.id}), put_data, format='json'
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -277,9 +250,7 @@ class ExamsViewSetTestCase(APITestCase):
         self.exam1.author = new_teacher
         self.exam1.save()
 
-        response = self.client.delete(
-            reverse(self.detail_view_name, kwargs={'pk': self.exam1.id})
-        )
+        response = self.client.delete(reverse(self.detail_view_name, kwargs={'pk': self.exam1.id}))
 
         self.assertEqual(
             response.data['detail'],
@@ -290,9 +261,7 @@ class ExamsViewSetTestCase(APITestCase):
     def test_exams_deletion(self):
         self.client.force_authenticate(user=self.teacher_user)
 
-        response = self.client.delete(
-            reverse(self.detail_view_name, kwargs={'pk': self.exam1.id})
-        )
+        response = self.client.delete(reverse(self.detail_view_name, kwargs={'pk': self.exam1.id}))
 
         self.assertEqual(Exam.objects.count(), 1)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/homeworks/tests.py
+++ b/homeworks/tests.py
@@ -32,7 +32,7 @@ class HomeworksViewSetTestCase(APITestCase):
             subject=self.subject,
             clazz=self.clazz,
             deadline=datetime.now().date(),
-            details='something interesting',
+            details='detailed explanation',
             author=self.teacher
         )
 
@@ -67,16 +67,10 @@ class HomeworksViewSetTestCase(APITestCase):
     def test_homeworks_detail_with_authenticated_user(self):
         self.client.force_authenticate(user=self.student_user)
 
-        response = self.client.get(
-            reverse(self.detail_view_name, kwargs={'pk': self.homework.id})
-        )
+        response = self.client.get(reverse(self.detail_view_name, kwargs={'pk': self.homework.id}))
 
-        self.assertEqual(
-            response.data['clazz']['number'], self.student.clazz.number
-        )
-        self.assertEqual(
-            response.data['clazz']['letter'], self.student.clazz.letter
-        )
+        self.assertEqual(response.data['clazz']['number'], self.student.clazz.number)
+        self.assertEqual(response.data['clazz']['letter'], self.student.clazz.letter)
         self.assertEqual(response.data['details'], self.homework.details)
         self.assertEqual(response.data['subject']['title'], self.subject.title)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -102,7 +96,7 @@ class HomeworksViewSetTestCase(APITestCase):
 
     def test_homeworks_creation_with_student_account(self):
         self.client.force_authenticate(user=self.student_user)
-        self.homework.details = 'С0002ГР'
+        self.homework.details = 'details'
         post_data = self.serializer_class(self.homework).data
 
         response = self.client.post(
@@ -117,12 +111,10 @@ class HomeworksViewSetTestCase(APITestCase):
 
     def test_homeworks_creation_with_too_long_details(self):
         self.client.force_authenticate(user=self.teacher_user)
-        self.homework.details = 'C0002ГР' * 256
+        self.homework.details = 'details' * 256
         post_data = self.serializer_class(self.homework).data
 
-        response = self.client.post(
-            reverse(self.list_view_name), post_data, format='json'
-        )
+        response = self.client.post(reverse(self.list_view_name), post_data, format='json')
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(
@@ -132,24 +124,20 @@ class HomeworksViewSetTestCase(APITestCase):
 
     def test_homeworks_creation_with_valid_details(self):
         self.client.force_authenticate(user=self.teacher_user)
-        self.homework.details = 'C0002ГР'
+        self.homework.details = 'details'
         post_data = self.serializer_class(self.homework).data
 
-        response = self.client.post(
-            reverse(self.list_view_name), post_data, format='json'
-        )
+        response = self.client.post(reverse(self.list_view_name), post_data, format='json')
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_homeworks_update_with_student_account(self):
         self.client.force_authenticate(user=self.student_user)
-        self.homework.details = 'С0002ГР'
+        self.homework.details = 'details'
         put_data = self.serializer_class(self.homework).data
 
         response = self.client.put(
-            reverse(self.detail_view_name, kwargs={'pk': self.homework.id}),
-            put_data,
-            format='json'
+            reverse(self.detail_view_name, kwargs={'pk': self.homework.id}), put_data, format='json'
         )
 
         self.assertEqual(
@@ -160,13 +148,11 @@ class HomeworksViewSetTestCase(APITestCase):
 
     def test_homeworks_update_with_too_long_details(self):
         self.client.force_authenticate(user=self.teacher_user)
-        self.homework.details = 'C0002ГР' * 256
+        self.homework.details = 'details' * 256
         put_data = self.serializer_class(self.homework).data
 
         response = self.client.put(
-            reverse(self.detail_view_name, kwargs={'pk': self.homework.id}),
-            put_data,
-            format='json'
+            reverse(self.detail_view_name, kwargs={'pk': self.homework.id}), put_data, format='json'
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -177,13 +163,11 @@ class HomeworksViewSetTestCase(APITestCase):
 
     def test_homeworks_update_with_valid_details(self):
         self.client.force_authenticate(user=self.teacher_user)
-        self.homework.details = 'C0002ГР'
+        self.homework.details = 'details'
         put_data = self.serializer_class(self.homework).data
 
         response = self.client.put(
-            reverse(self.detail_view_name, kwargs={'pk': self.homework.id}),
-            put_data,
-            format='json'
+            reverse(self.detail_view_name, kwargs={'pk': self.homework.id}), put_data, format='json'
         )
 
         self.assertEqual(response.data['details'], self.homework.details)
@@ -199,7 +183,7 @@ class HomeworksViewSetTestCase(APITestCase):
 
         response = self.client.put(
             reverse(self.detail_view_name, kwargs={'pk': self.homework.id}),
-            {'details': 'HAHAHA I AM ANONYMOUS!'},
+            {'details': 'detailed information'},
             format='json'
         )
 
@@ -260,35 +244,27 @@ class SubmissionsViewSetTestCase(APITestCase):
             subject=self.subject,
             clazz=self.clazz,
             deadline=datetime.now().date(),
-            details='something interesting',
+            details='detailed explanation',
             author=self.teacher
         )
 
         self.student1_submission = Submission.objects.create(
             homework=self.homework,
             student=self.student1,
-            content='this is my solution.'
+            content='solution'
         )
         self.student2_submission = Submission.objects.create(
             homework=self.homework,
             student=self.student2,
-            content='noonecansaveyoufromwhatyouwant'
+            content='test'
         )
 
     def test_submissions_list_with_anonymous_user(self):
         response = self.client.get(
-            reverse(
-                self.list_view_name,
-                kwargs={
-                    'homeworks_pk': self.homework.id
-                }
-            )
+            reverse(self.list_view_name, kwargs={'homeworks_pk': self.homework.id})
         )
 
-        self.assertEqual(
-            response.data['detail'],
-            'Authentication credentials were not provided.'
-        )
+        self.assertEqual(response.data['detail'], 'Authentication credentials were not provided.')
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_submissions_detail_with_anonymous_user(self):
@@ -302,28 +278,17 @@ class SubmissionsViewSetTestCase(APITestCase):
             )
         )
 
-        self.assertEqual(
-            response.data['detail'],
-            'Authentication credentials were not provided.'
-        )
+        self.assertEqual(response.data['detail'], 'Authentication credentials were not provided.')
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_submissions_list_with_student_user(self):
         self.client.force_authenticate(user=self.student_user1)
 
         response = self.client.get(
-            reverse(
-                self.list_view_name,
-                kwargs={
-                    'homeworks_pk': self.homework.id
-                }
-            )
+            reverse(self.list_view_name, kwargs={'homeworks_pk': self.homework.id})
         )
 
-        self.assertNotEqual(
-            response.data,
-            SubmissionSerializer(self.student2_submission).data
-        )
+        self.assertNotEqual(response.data, SubmissionSerializer(self.student2_submission).data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_submissions_detail_with_student_user(self):
@@ -363,12 +328,7 @@ class SubmissionsViewSetTestCase(APITestCase):
         self.client.force_authenticate(user=self.teacher_user)
 
         response = self.client.get(
-            reverse(
-                self.list_view_name,
-                kwargs={
-                    'homeworks_pk': self.homework.id
-                }
-            )
+            reverse(self.list_view_name, kwargs={'homeworks_pk': self.homework.id})
         )
 
         self.assertEqual(response.data[1]['id'], self.student1_submission.id)
@@ -417,12 +377,7 @@ class SubmissionsViewSetTestCase(APITestCase):
         )
 
         response = self.client.get(
-            reverse(
-                self.list_view_name,
-                kwargs={
-                    'homeworks_pk': self.homework.id
-                }
-            )
+            reverse(self.list_view_name, kwargs={'homeworks_pk': self.homework.id})
         )
 
         self.assertEqual(response.data, [])
@@ -432,12 +387,7 @@ class SubmissionsViewSetTestCase(APITestCase):
         self.client.force_authenticate(user=self.teacher_user)
 
         response = self.client.post(
-            reverse(
-                self.list_view_name,
-                kwargs={
-                    'homeworks_pk': self.homework.id
-                }
-            ),
+            reverse(self.list_view_name, kwargs={'homeworks_pk': self.homework.id}),
             {'content': 'test'},
             format='json'
         )
@@ -452,12 +402,7 @@ class SubmissionsViewSetTestCase(APITestCase):
         self.client.force_authenticate(user=self.student_user1)
 
         response = self.client.post(
-            reverse(
-                self.list_view_name,
-                kwargs={
-                    'homeworks_pk': self.homework.id
-                }
-            ),
+            reverse(self.list_view_name, kwargs={'homeworks_pk': self.homework.id}),
             {'content': 'test'},
             format='json'
         )

--- a/materials/tests.py
+++ b/materials/tests.py
@@ -27,9 +27,9 @@ class MaterialsViewSetTestCase(APITestCase):
         self.teacher = Teacher.objects.create(user=self.teacher_user, subject=self.subject)
 
         self.material = Material.objects.create(
-            title='bla bla bla',
-            section='Quadratic inequations',
-            content='Here I will put some useful links for the current topic.',
+            title='test material',
+            section='test material section',
+            content='test material content',
             class_number=self.clazz.number,
             subject=self.subject,
             author=self.teacher
@@ -37,12 +37,7 @@ class MaterialsViewSetTestCase(APITestCase):
 
     def test_materials_list_with_anonymous_user(self):
         response = self.client.get(
-            reverse(
-                self.list_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id
-                }
-            )
+            reverse(self.list_view_name, kwargs={'subject_pk': self.material.subject.id})
         )
 
         self.assertEqual(
@@ -55,10 +50,7 @@ class MaterialsViewSetTestCase(APITestCase):
         response = self.client.get(
             reverse(
                 self.detail_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id,
-                    'pk': self.material.id
-                }
+                kwargs={'subject_pk': self.material.subject.id, 'pk': self.material.id}
             )
         )
 
@@ -72,12 +64,7 @@ class MaterialsViewSetTestCase(APITestCase):
         self.client.force_authenticate(user=self.student_user)
 
         response = self.client.get(
-            reverse(
-                self.list_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id
-                }
-            )
+            reverse(self.list_view_name, kwargs={'subject_pk': self.material.subject.id})
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -88,10 +75,7 @@ class MaterialsViewSetTestCase(APITestCase):
         response = self.client.get(
             reverse(
                 self.detail_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id,
-                    'pk': self.material.id
-                }
+                kwargs={'subject_pk': self.material.subject.id, 'pk': self.material.id}
             )
         )
 
@@ -99,16 +83,11 @@ class MaterialsViewSetTestCase(APITestCase):
 
     def test_materials_creation_with_student_account(self):
         self.client.force_authenticate(user=self.student_user)
-        self.material.title = 'С0002ГР'
+        self.material.title = 'test title'
         post_data = self.serializer_class(self.material).data
 
         response = self.client.post(
-            reverse(
-                self.list_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id
-                }
-            ),
+            reverse(self.list_view_name, kwargs={'subject_pk': self.material.subject.id}),
             post_data,
             format='json'
         )
@@ -125,41 +104,27 @@ class MaterialsViewSetTestCase(APITestCase):
         post_data = self.serializer_class(self.material).data
 
         response = self.client.post(
-            reverse(
-                self.list_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id
-                }
-            ),
+            reverse(self.list_view_name, kwargs={'subject_pk': self.material.subject.id}),
             post_data,
             format='json'
         )
 
-        self.assertEqual(
-            response.data['title'],
-            ['Ensure this field has at least 3 characters.']
-        )
+        self.assertEqual(response.data['title'], ['Ensure this field has at least 3 characters.'])
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_materials_creation_with_too_long_title(self):
         self.client.force_authenticate(user=self.teacher_user)
-        self.material.title = 'Svetlosyanka' * 150
+        self.material.title = 'test title' * 150
         post_data = self.serializer_class(self.material).data
 
         response = self.client.post(
-            reverse(
-                self.list_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id
-                }
-            ),
+            reverse(self.list_view_name, kwargs={'subject_pk': self.material.subject.id}),
             post_data,
             format='json'
         )
 
         self.assertEqual(
-            response.data['title'],
-            ['Ensure this field has no more than 150 characters.']
+            response.data['title'], ['Ensure this field has no more than 150 characters.']
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -169,12 +134,7 @@ class MaterialsViewSetTestCase(APITestCase):
         post_data = self.serializer_class(self.material).data
 
         response = self.client.post(
-            reverse(
-                self.list_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id
-                }
-            ),
+            reverse(self.list_view_name, kwargs={'subject_pk': self.material.subject.id}),
             post_data,
             format='json'
         )
@@ -187,23 +147,17 @@ class MaterialsViewSetTestCase(APITestCase):
 
     def test_materials_creation_with_too_long_section(self):
         self.client.force_authenticate(user=self.teacher_user)
-        self.material.section = 'Svetlosyanka' * 150
+        self.material.section = 'test title' * 150
         post_data = self.serializer_class(self.material).data
 
         response = self.client.post(
-            reverse(
-                self.list_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id
-                }
-            ),
+            reverse(self.list_view_name, kwargs={'subject_pk': self.material.subject.id}),
             post_data,
             format='json'
         )
 
         self.assertEqual(
-            response.data['section'],
-            ['Ensure this field has no more than 150 characters.']
+            response.data['section'], ['Ensure this field has no more than 150 characters.']
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -213,12 +167,7 @@ class MaterialsViewSetTestCase(APITestCase):
         post_data = self.serializer_class(self.material).data
 
         response = self.client.post(
-            reverse(
-                self.list_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id
-                }
-            ),
+            reverse(self.list_view_name, kwargs={'subject_pk': self.material.subject.id}),
             post_data,
             format='json'
         )
@@ -228,18 +177,13 @@ class MaterialsViewSetTestCase(APITestCase):
 
     def test_materials_creation_with_valid_data(self):
         self.client.force_authenticate(user=self.teacher_user)
-        self.material.title = 'Hvala!'
-        self.material.section = 'TBA'
-        self.material.content = 'ELSYSER is damn good!'
+        self.material.title = 'test title'
+        self.material.section = 'test section'
+        self.material.content = 'test content'
         post_data = self.serializer_class(self.material).data
 
         response = self.client.post(
-            reverse(
-                self.list_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id
-                }
-            ),
+            reverse(self.list_view_name, kwargs={'subject_pk': self.material.subject.id}),
             post_data,
             format='json'
         )
@@ -248,39 +192,32 @@ class MaterialsViewSetTestCase(APITestCase):
 
     def test_materials_update_with_student_account(self):
         self.client.force_authenticate(user=self.student_user)
-        self.material.title = 'С0002ГР'
+        self.material.title = 'test title'
         put_data = self.serializer_class(self.material).data
 
         response = self.client.put(
             reverse(
                 self.detail_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id,
-                    'pk': self.material.id
-                }
+                kwargs={'subject_pk': self.material.subject.id, 'pk': self.material.id}
             ),
             put_data,
             format='json'
         )
 
         self.assertEqual(
-            response.data['detail'],
-            'Only teachers are allowed to view and modify this content.'
+            response.data['detail'], 'Only teachers are allowed to view and modify this content.'
         )
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_materials_update_with_invalid_subject_id(self):
         self.client.force_authenticate(user=self.teacher_user)
-        self.material.title = 'Hvala!'
+        self.material.title = 'test title'
         put_data = self.serializer_class(self.material).data
 
         response = self.client.put(
             reverse(
                 self.detail_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id + 1,
-                    'pk': self.material.id
-                }
+                kwargs={'subject_pk': self.material.subject.id + 1, 'pk': self.material.id}
             ),
             put_data,
             format='json'
@@ -291,16 +228,13 @@ class MaterialsViewSetTestCase(APITestCase):
 
     def test_materials_update_with_invalid_id(self):
         self.client.force_authenticate(user=self.teacher_user)
-        self.material.title = 'Hvala!'
+        self.material.title = 'test title'
         put_data = self.serializer_class(self.material).data
 
         response = self.client.put(
             reverse(
                 self.detail_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id,
-                    'pk': self.material.id + 1
-                }
+                kwargs={'subject_pk': self.material.subject.id, 'pk': self.material.id + 1}
             ),
             put_data,
             format='json'
@@ -317,41 +251,31 @@ class MaterialsViewSetTestCase(APITestCase):
         response = self.client.put(
             reverse(
                 self.detail_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id,
-                    'pk': self.material.id
-                }
+                kwargs={'subject_pk': self.material.subject.id, 'pk': self.material.id}
             ),
             put_data,
             format='json'
         )
 
-        self.assertEqual(
-            response.data['title'],
-            ['Ensure this field has at least 3 characters.']
-        )
+        self.assertEqual(response.data['title'], ['Ensure this field has at least 3 characters.'])
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_materials_update_with_too_long_title(self):
         self.client.force_authenticate(user=self.teacher_user)
-        self.material.title = 'Svetlosyanka' * 150
+        self.material.title = 'test title' * 150
         put_data = self.serializer_class(self.material).data
 
         response = self.client.put(
             reverse(
                 self.detail_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id,
-                    'pk': self.material.id
-                }
+                kwargs={'subject_pk': self.material.subject.id, 'pk': self.material.id}
             ),
             put_data,
             format='json'
         )
 
         self.assertEqual(
-            response.data['title'],
-            ['Ensure this field has no more than 150 characters.']
+            response.data['title'], ['Ensure this field has no more than 150 characters.']
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -363,41 +287,31 @@ class MaterialsViewSetTestCase(APITestCase):
         response = self.client.put(
             reverse(
                 self.detail_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id,
-                    'pk': self.material.id
-                }
+                kwargs={'subject_pk': self.material.subject.id, 'pk': self.material.id}
             ),
             put_data,
             format='json'
         )
 
-        self.assertEqual(
-            response.data['section'],
-            ['Ensure this field has at least 3 characters.']
-        )
+        self.assertEqual(response.data['section'], ['Ensure this field has at least 3 characters.'])
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_materials_update_with_too_long_section(self):
         self.client.force_authenticate(user=self.teacher_user)
-        self.material.section = 'Svetlosyanka' * 150
+        self.material.section = 'test title' * 150
         put_data = self.serializer_class(self.material).data
 
         response = self.client.put(
             reverse(
                 self.detail_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id,
-                    'pk': self.material.id
-                }
+                kwargs={'subject_pk': self.material.subject.id, 'pk': self.material.id}
             ),
             put_data,
             format='json'
         )
 
         self.assertEqual(
-            response.data['section'],
-            ['Ensure this field has no more than 150 characters.']
+            response.data['section'], ['Ensure this field has no more than 150 characters.']
         )
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -409,35 +323,26 @@ class MaterialsViewSetTestCase(APITestCase):
         response = self.client.put(
             reverse(
                 self.detail_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id,
-                    'pk': self.material.id
-                }
+                kwargs={'subject_pk': self.material.subject.id, 'pk': self.material.id}
             ),
             put_data,
             format='json'
         )
 
-        self.assertEqual(
-            response.data['content'],
-            ['This field may not be blank.']
-        )
+        self.assertEqual(response.data['content'], ['This field may not be blank.'])
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_materials_update_with_valid_data(self):
         self.client.force_authenticate(user=self.teacher_user)
-        self.material.title = 'Hvala!'
-        self.material.section = 'TBA'
-        self.material.content = 'ELSYSER is damn good!'
+        self.material.title = 'test title'
+        self.material.section = 'test section'
+        self.material.content = 'test content'
         put_data = self.serializer_class(self.material).data
 
         response = self.client.put(
             reverse(
                 self.detail_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id,
-                    'pk': self.material.id
-                }
+                kwargs={'subject_pk': self.material.subject.id, 'pk': self.material.id}
             ),
             put_data,
             format='json'
@@ -456,12 +361,9 @@ class MaterialsViewSetTestCase(APITestCase):
         response = self.client.put(
             reverse(
                 self.detail_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id,
-                    'pk': self.material.id
-                }
+                kwargs={'subject_pk': self.material.subject.id, 'pk': self.material.id}
             ),
-            {'topic': 'HAHAHA I AM ANONYMOUS!'},
+            {'topic': 'test topic'},
             format='json'
         )
 
@@ -477,10 +379,7 @@ class MaterialsViewSetTestCase(APITestCase):
         response = self.client.delete(
             reverse(
                 self.detail_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id + 1,
-                    'pk': self.material.id
-                }
+                kwargs={'subject_pk': self.material.subject.id + 1, 'pk': self.material.id}
             )
         )
 
@@ -493,10 +392,7 @@ class MaterialsViewSetTestCase(APITestCase):
         response = self.client.delete(
             reverse(
                 self.detail_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id,
-                    'pk': self.material.id + 1
-                }
+                kwargs={'subject_pk': self.material.subject.id, 'pk': self.material.id + 1}
             )
         )
 
@@ -514,10 +410,7 @@ class MaterialsViewSetTestCase(APITestCase):
         response = self.client.delete(
             reverse(
                 self.detail_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id,
-                    'pk': self.material.id
-                }
+                kwargs={'subject_pk': self.material.subject.id, 'pk': self.material.id}
             ),
         )
 
@@ -533,10 +426,7 @@ class MaterialsViewSetTestCase(APITestCase):
         response = self.client.delete(
             reverse(
                 self.detail_view_name,
-                kwargs={
-                    'subject_pk': self.material.subject.id,
-                    'pk': self.material.id
-                }
+                kwargs={'subject_pk': self.material.subject.id, 'pk': self.material.id}
             ),
         )
 


### PR DESCRIPTION
Unit tests for _exams_, _homeworks_ and _materials_ modules have been unified and shortened, as observing PEP8 line length limitation (80 symbols)